### PR TITLE
Hackage release prep

### DIFF
--- a/rme-what4/CHANGELOG.md
+++ b/rme-what4/CHANGELOG.md
@@ -1,5 +1,5 @@
 # Revision history for rme-what4
 
-## 0.1.0.0 --
+## 0.1 --
 
 * First version.

--- a/rme-what4/rme-what4.cabal
+++ b/rme-what4/rme-what4.cabal
@@ -1,6 +1,6 @@
 cabal-version:      3.0
 name:               rme-what4
-version:            0.1.0.0
+version:            0.1
 synopsis:           What4 adapter for the RME solver
 license:            BSD-3-Clause
 license-file:       LICENSE

--- a/rme/CHANGELOG.md
+++ b/rme/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Revision history for rme-what4
+# Revision history for rme
 
 ## 0.1 -- TBA
 

--- a/rme/rme.cabal
+++ b/rme/rme.cabal
@@ -7,7 +7,7 @@ Build-type:         Simple
 License:            BSD-3-Clause
 extra-doc-files:    CHANGELOG.md
 License-file:       LICENSE
-Copyright:          (c) 2016 Galois Inc.
+Copyright:          (c) 2016-2025 Galois Inc.
 Category:           Formal Methods
 Synopsis:           Reed-Muller Expansion normal form for Boolean Formulas
 Description:

--- a/rme/rme.cabal
+++ b/rme/rme.cabal
@@ -5,6 +5,7 @@ Author:             Galois, Inc.
 Maintainer:         huffman@galois.com
 Build-type:         Simple
 License:            BSD-3-Clause
+extra-doc-files:    CHANGELOG.md
 License-file:       LICENSE
 Copyright:          (c) 2016 Galois Inc.
 Category:           Formal Methods


### PR DESCRIPTION
This changes are in preparation for a pending Hackage release of `rme` and `rme-what4`. See #2.