### PR TITLE
Add support for uninterpreted functions returning arrays

### DIFF
--- a/rme/CHANGELOG.md
+++ b/rme/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## next
 
+* Added partial support for arrays returned from symbolic functions.
+  Expressions must be exactly of the form: `select (f args) ix`. This is
+  used to support the translation of uninterpreted functions new in
+  SAW.
+
+* Added support for concrete integers as needed for SAW's above translation
+  used to index the symbolic array results.
+
 ## 0.1.1
 
 * Added `Ord` instance for `RME`


### PR DESCRIPTION
This adds narrow support for selecting from arrays returned by uninterpreted functions as found in SAW's translation.

This also adds support for concrete integer values as used for indexing arrays in SAW's translation.